### PR TITLE
Create Docker image for elm 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following versions are currently supported:
  * 0.15.1
  * 0.16
  * 0.17
-
+ * 0.18
 
 ### Issues
 

--- a/elm/0.18/Dockerfile
+++ b/elm/0.18/Dockerfile
@@ -1,4 +1,5 @@
-FROM haskell:7.10.2
+FROM haskell:7.10.3
+
 MAINTAINER Michael Porter <mike@codesimple.net>
 
 ENV ELM_VER=0.18

--- a/elm/0.18/Dockerfile
+++ b/elm/0.18/Dockerfile
@@ -1,0 +1,20 @@
+FROM haskell:7.10.2
+MAINTAINER Michael Porter <mike@codesimple.net>
+
+ENV ELM_VER=0.18
+
+RUN apt-get update && apt-get install -y \
+   curl \
+   git \
+   libtinfo-dev \
+   nodejs
+
+ENV PATH /opt/Elm-Platform/$ELM_VER/.cabal-sandbox/bin:$PATH
+
+WORKDIR /opt
+
+RUN curl https://raw.githubusercontent.com/elm-lang/elm-platform/11c8ecb81a58b82a25c90145418cd70fa61d1679/installers/BuildFromSource.hs > BuildFromSource.hs
+
+RUN runhaskell BuildFromSource.hs $ELM_VER
+
+ENTRYPOINT ["elm"]


### PR DESCRIPTION
# Changes

- updated `ELM_VER` to 0.18
- bumped haskell image to `7.10.3`

I tested the image on Mac OS 10.12