### PR TITLE
Use Elm 0.19-no-deps and LTS node 10.16.0-stretch-slim

### DIFF
--- a/elm/0.19/Dockerfile
+++ b/elm/0.19/Dockerfile
@@ -2,6 +2,6 @@ FROM node:7.2.0
 
 MAINTAINER Michael Porter <mike@codesimple.net>
 
-RUN npm install -g elm@0.19.0-bugfix2
+RUN npm install --unsafe-perm -g elm@0.19.0-no-deps
 
 ENTRYPOINT ["elm"]

--- a/elm/0.19/Dockerfile
+++ b/elm/0.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.2.0
+FROM node:10.16.0-stretch-slim
 
 MAINTAINER Michael Porter <mike@codesimple.net>
 


### PR DESCRIPTION
Using the latest release of elm 0.19 (as of 2019-6-6), and I also updated node to LTS 10.16.0 (also latest as of 2019-6-6).

The `stretch-slim` base docker image is ~50MB instead of ~400MB for the `node` image.

I added the `--unsafe-perm` option to the `npm install` command since this npm apparently switches to a regular user and I get this error during installing if I don't include it:
```
-- ERROR -----------------------------------------------------------------------

I had some trouble writing file to disk. It is saying:

Error: EACCES: permission denied, open '/usr/local/lib/node_modules/elm/bin/elm'

NOTE: You can avoid npm entirely by downloading directly from:
https://github.com/elm/compiler/releases/download/0.19.0/binary-for-linux-64-bit.gz
All this package does is download that file and put it somewhere.

--------------------------------------------------------------------------------
```